### PR TITLE
packer/centos,packer/ubuntu: adjust MaxSessions to 1000

### DIFF
--- a/packer/centos/script/sshd.sh
+++ b/packer/centos/script/sshd.sh
@@ -4,5 +4,7 @@ echo '==> Configuring sshd_config options'
 
 echo '==> Turning off sshd DNS lookup to prevent timeout delay'
 echo "UseDNS no" >> /etc/ssh/sshd_config
-echo '==> Disablng GSSAPI authentication to prevent timeout delay'
+echo '==> Disabling GSSAPI authentication to prevent timeout delay'
 echo "GSSAPIAuthentication no" >> /etc/ssh/sshd_config
+echo "==> Setting MaxSessions to 1000. Needed for systemtests"
+echo "MaxSessions 1000" >> /etc/ssh/sshd_config

--- a/packer/ubuntu/script/sshd.sh
+++ b/packer/ubuntu/script/sshd.sh
@@ -1,3 +1,4 @@
 #!/bin/bash -eux
 
 echo "UseDNS no" >> /etc/ssh/sshd_config
+echo "MaxSessions 1000" >> /etc/ssh/sshd_config


### PR DESCRIPTION
this is necessary for high-speed parallel tests to pass. the ssh library opens a new session -- not a connection -- for each operation. Now, `RunCommandBackground` in the systemtests-utils, at least for me, effectively leaks a session. I don't think this is a bad thing, but `sshd` needs to be adjusted for this to work without expensive sleep calls which slow down the tests significantly.

@mapuri PTAL

Signed-off-by: Erik Hollensbe github@hollensbe.org
