### PR TITLE
ansible/roles/etcd: do not join the online master addr if we are the online master addr

### DIFF
--- a/ansible/roles/etcd/templates/etcd.j2
+++ b/ansible/roles/etcd/templates/etcd.j2
@@ -20,7 +20,7 @@ case $1 in
 start)
     ONLINE_MASTER_ADDR={{ online_master_addr }}
     # if a master address is provided then we need to ad dthe node to existing cluster
-    if [ "$ONLINE_MASTER_ADDR" != "" ]; then
+    if [ "$ONLINE_MASTER_ADDR" != "" -a "$ONLINE_MASTER_ADDR" != "{{ node_addr }}" ]; then
         # XXX: There seems an issue using etcdctl with ETCD_INITIAL_ADVERTISE_PEER_URLS so passing
         # ETCD_LISTEN_PEER_URLS for now
         out=`etcdctl --peers="{{ online_master_addr }}:2379,{{ online_master_addr }}:4001" \


### PR DESCRIPTION
We are already using this in volplugin master.

This small change makes it so this is all you need in `group_vars`:

``` yaml
node_name: "{{ ansible_hostname }}"
node_addr: "{{ ansible_enp0s8.ipv4.address }}"
online_master_addr: "192.168.24.10"
```

And in the master case, it will not try to join itself now if `ansible_enp0s8.ipv4.address` equals the `online_master_addr`
