### PR TITLE
centos: use overlay graph driver for docker

### DIFF
--- a/packer/centos/script/docker.sh
+++ b/packer/centos/script/docker.sh
@@ -15,6 +15,12 @@ echo "==> Add the connected "${USER}" to the docker group."
 gpasswd -a ${USER} docker
 gpasswd -a ${SSH_USERNAME} docker
 
+service docker stop
+echo "==> Cleaning up Docker directory"
+rm -rf /var/lib/docker/*
+echo "==> Configuring Docker daemon"
+sed -i "s/daemon -H/daemon -s overlay -H/g" /usr/lib/systemd/system/docker.service
+systemctl daemon-reload
 echo "==> Starting docker"
 service docker start
 echo "==> Enabling docker to start on reboot"


### PR DESCRIPTION
This PR makes centos and ubuntu use overlay as the graph driver.

This PR is untested because my host is currently running into kernel panics.
