### PR TITLE
ansible: set volmaster address on worker nodes

### DIFF
--- a/ansible/roles/contiv_storage/files/volplugin
+++ b/ansible/roles/contiv_storage/files/volplugin
@@ -1,1 +1,0 @@
-VOLPLUGIN_ARGS='--debug'

--- a/ansible/roles/contiv_storage/tasks/main.yml
+++ b/ansible/roles/contiv_storage/tasks/main.yml
@@ -23,7 +23,7 @@
   when: run_as == "master"
 
 - name: start volmaster
-  service: name=volmaster state=started
+  service: name=volmaster state=restarted
   when: run_as == "master"
 
 - name: copy environment file for volsupervisor
@@ -35,14 +35,14 @@
   when: run_as == "master"
 
 - name: start volsupervisor
-  service: name=volsupervisor state=started
+  service: name=volsupervisor state=restarted
   when: run_as == "master"
 
 - name: copy environment file for volplugin
-  copy: src=volplugin dest=/etc/default/volplugin
+  template: src=volplugin.j2 dest=/etc/default/volplugin
 
 - name: copy systemd units for volplugin
   copy: src=volplugin.service dest=/etc/systemd/system/volplugin.service
 
 - name: start volplugin
-  service: name=volplugin state=started
+  service: name=volplugin state=restarted

--- a/ansible/roles/contiv_storage/templates/volplugin.j2
+++ b/ansible/roles/contiv_storage/templates/volplugin.j2
@@ -1,0 +1,5 @@
+{% if online_master_addr == node_addr or online_master_addr == "" %}
+VOLPLUGIN_ARGS='--debug'
+{% else %}
+VOLPLUGIN_ARGS='--debug --master {{ online_master_addr }}:9005'
+{% endif %}


### PR DESCRIPTION
This is needed to allow `docker volume create` to work in a multihost environment where volmaster and volplugin are not co-located.
