### PR TITLE
ansible: run etcd in proxy mode on worker nodes

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -6,4 +6,5 @@ env:
 
 node_name: "{{ ansible_hostname }}"
 node_addr: "{{ hostvars[ansible_hostname]['ansible_' + monitor_interface]['ipv4']['address'] }}"
-online_master_addr: "192.168.24.10"
+master_addr: ""
+master_name: ""

--- a/ansible/roles/contiv_network/tasks/main.yml
+++ b/ansible/roles/contiv_network/tasks/main.yml
@@ -39,7 +39,7 @@
   when: run_as == "master"
 
 - name: setup netmaster host alias on workers
-  shell: echo "{{ online_master_addr }} netmaster" >> /etc/hosts
+  shell: echo "{{ master_addr }} netmaster" >> /etc/hosts
   when: run_as == "worker"
 
 # XXX: need to move the following to correct roles

--- a/ansible/roles/contiv_storage/templates/volplugin.j2
+++ b/ansible/roles/contiv_storage/templates/volplugin.j2
@@ -1,5 +1,5 @@
-{% if online_master_addr == node_addr or online_master_addr == "" %}
+{% if master_addr == node_addr or master_addr == "" %}
 VOLPLUGIN_ARGS='--debug'
 {% else %}
-VOLPLUGIN_ARGS='--debug --master {{ online_master_addr }}:9005'
+VOLPLUGIN_ARGS='--debug --master {{ master_addr }}:9005'
 {% endif %}

--- a/ansible/roles/etcd/tasks/main.yml
+++ b/ansible/roles/etcd/tasks/main.yml
@@ -8,4 +8,4 @@
   copy: src=etcd.service dest=/etc/systemd/system/etcd.service
 
 - name: start etcd
-  shell: systemctl daemon-reload && systemctl start etcd
+  service: name=etcd state=started

--- a/ansible/roles/etcd/templates/etcd.j2
+++ b/ansible/roles/etcd/templates/etcd.j2
@@ -18,12 +18,17 @@ export ETCD_INITIAL_CLUSTER="{{ node_name }}=http://{{ node_addr }}:{{ etcd_peer
 
 case $1 in
 start)
-    ONLINE_MASTER_ADDR={{ online_master_addr }}
-    # if a master address is provided then we need to ad dthe node to existing cluster
+    ONLINE_MASTER_ADDR={{ master_addr }}
+    {% if run_as == "worker" %}
+    # on worker nodes, run etcd in proxy mode
+    export ETCD_PROXY=on
+    export ETCD_INITIAL_CLUSTER="{{ master_name }}=http://{{ master_addr }}:{{ etcd_peer_port1 }},{{ master_name }}=http://{{ master_addr }}:{{ etcd_peer_port2 }}"
+    {% else %}
+    # if a master address is provided then we need to add the node to existing cluster
     if [ "$ONLINE_MASTER_ADDR" != "" -a "$ONLINE_MASTER_ADDR" != "{{ node_addr }}" ]; then
         # XXX: There seems an issue using etcdctl with ETCD_INITIAL_ADVERTISE_PEER_URLS so passing
         # ETCD_LISTEN_PEER_URLS for now
-        out=`etcdctl --peers="{{ online_master_addr }}:{{ etcd_client_port1 }},{{ online_master_addr }}:{{ etcd_client_port2 }}" \
+        out=`etcdctl --peers="{{ master_addr }}:{{ etcd_client_port1 }},{{ master_addr }}:{{ etcd_client_port2 }}" \
             member add {{ node_name }} "$ETCD_LISTEN_PEER_URLS"`
         if [ $? -ne 0 ]; then
             echo "failed to add member {{ node_name }}"
@@ -32,6 +37,7 @@ start)
         # parse and export the environment returned by member add
         export `echo $out | awk -F 'ETCD_' '{print "ETCD_"$2 "ETCD_"$3 "ETCD_"$4}' | sed s/\"//g`
     fi
+    {% endif %}
 
     #start etcd
     echo "==> starting etcd with environment:" `env`

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -36,7 +36,7 @@
   environment: env
   roles:
   - { role: docker }
-  - { role: etcd }
+  - { role: etcd, run_as: master }
   - { role: swarm, run_as: master }
   - { role: contiv_network, run_as: master }
   - { role: contiv_storage, run_as: master }
@@ -48,7 +48,7 @@
   environment: env
   roles:
   - { role: docker }
-  - { role: etcd }
+  - { role: etcd, run_as: worker }
   - { role: swarm, run_as: worker }
   - { role: contiv_network, run_as: worker }
   - { role: contiv_storage, run_as: worker }


### PR DESCRIPTION
This shall allow provisioning multiple worker nodes in parallel.

Also renamed 'online_master_addr' variable to just 'master_addr'.
