### PR TITLE
ansible: make client.admin key available on osd only nodes

### DIFF
--- a/ansible/roles/ceph-osd/tasks/pre_requisite.yml
+++ b/ansible/roles/ceph-osd/tasks/pre_requisite.yml
@@ -19,3 +19,14 @@
     group=root
     mode=600
   when: cephx
+
+- name: copy client.admin key to `osd` only nodes as well to allow volplugin run rbd commands
+  copy: >
+    src=fetch/{{ fsid }}/etc/ceph/ceph.client.admin.keyring
+    dest=/etc/ceph/ceph.client.admin.keyring
+    owner=root
+    group=root
+    mode=600
+  when:
+      cephx and
+      '{{ mon_group_name }}' not in {{ group_names }}

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -31,7 +31,7 @@
   - { role: docker }
   - { role: etcd, run_as: master }
   - { role: ceph-mon, mon_group_name: service-master }
-  - { role: ceph-osd, osd_group_name: service-master }
+  - { role: ceph-osd, mon_group_name: service-master, osd_group_name: service-master }
   - { role: swarm, run_as: master }
   - { role: contiv_network, run_as: master }
   - { role: contiv_storage, run_as: master }


### PR DESCRIPTION
This enhancement copies over the client.admin keys on the nodes that only run osd. This shall enable volplugin perform rbd client operations on such nodes.

It reverts the previous workaround we had to put of running both mons and osds on all nodes in a cluster.
