### PR TITLE
ansible: etcd provisioning enhancements

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -4,11 +4,10 @@
 
 node_name: "{{ ansible_hostname }}"
 node_addr: "{{ hostvars[ansible_hostname]['ansible_' + monitor_interface]['ipv4']['address'] }}"
-master_addr: "{{ hostvars[ansible_hostname]['ansible_' + monitor_interface]['ipv4']['address'] }}"
 
 # following variables are used in one or more roles, but have no good default value to pick from.
 # Leaving them as commented so that playbooks can fail early due to variable not defined error.
 
 # env:
 # service_vip:
-# master_name:
+# monitor_interface:

--- a/ansible/roles/etcd/templates/etcd.j2
+++ b/ansible/roles/etcd/templates/etcd.j2
@@ -8,36 +8,55 @@ fi
 
 export ETCD_NAME={{ node_name }}
 export ETCD_DATA_DIR=/var/lib/etcd
-export ETCD_INITIAL_CLUSTER_STATE=new
 export ETCD_INITIAL_CLUSTER_TOKEN=contiv-cluster
 export ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:{{ etcd_client_port1 }},http://0.0.0.0:{{ etcd_client_port2 }}
 export ETCD_ADVERTISE_CLIENT_URLS=http://{{ node_addr }}:{{ etcd_client_port1 }},http://{{ node_addr }}:{{ etcd_client_port2 }}
 export ETCD_INITIAL_ADVERTISE_PEER_URLS=http://{{ node_addr }}:{{ etcd_peer_port1 }},http://{{ node_addr }}:{{ etcd_peer_port2 }}
 export ETCD_LISTEN_PEER_URLS=http://{{ node_addr }}:{{ etcd_peer_port1 }}
-export ETCD_INITIAL_CLUSTER="{{ node_name }}=http://{{ node_addr }}:{{ etcd_peer_port1 }},{{ node_name }}=http://{{ node_addr }}:{{ etcd_peer_port2 }}"
 
 case $1 in
 start)
-    ONLINE_MASTER_ADDR={{ master_addr }}
-    {% if run_as == "worker" %}
-    # on worker nodes, run etcd in proxy mode
+    {% macro add_proxy() -%}
     export ETCD_PROXY=on
-    export ETCD_INITIAL_CLUSTER="{{ master_name }}=http://{{ master_addr }}:{{ etcd_peer_port1 }},{{ master_name }}=http://{{ master_addr }}:{{ etcd_peer_port2 }}"
-    {% else %}
-    # if a master address is provided then we need to add the node to existing cluster
-    if [ "$ONLINE_MASTER_ADDR" != "" -a "$ONLINE_MASTER_ADDR" != "{{ node_addr }}" ]; then
-        # XXX: There seems an issue using etcdctl with ETCD_INITIAL_ADVERTISE_PEER_URLS so passing
-        # ETCD_LISTEN_PEER_URLS for now
-        out=`etcdctl --peers="{{ master_addr }}:{{ etcd_client_port1 }},{{ master_addr }}:{{ etcd_client_port2 }}" \
-            member add {{ node_name }} "$ETCD_LISTEN_PEER_URLS"`
-        if [ $? -ne 0 ]; then
-            echo "failed to add member {{ node_name }}"
-            exit 1
-        fi
-        # parse and export the environment returned by member add
-        export `echo $out | awk -F 'ETCD_' '{print "ETCD_"$2 "ETCD_"$3 "ETCD_"$4}' | sed s/\"//g`
+    export ETCD_INITIAL_CLUSTER="{{ etcd_master_name }}=http://{{ etcd_master_addr }}:{{ etcd_peer_port1 }},{{ etcd_master_name }}=http://{{ etcd_master_addr }}:{{ etcd_peer_port2 }}"
+    {% endmacro -%}
+
+    {% macro add_member() -%}
+    # XXX: There seems an issue using etcdctl with ETCD_INITIAL_ADVERTISE_PEER_URLS so passing
+    # ETCD_LISTEN_PEER_URLS for now
+    out=`etcdctl --peers="{{ etcd_master_addr }}:{{ etcd_client_port1 }},{{ etcd_master_addr }}:{{ etcd_client_port2 }}" \
+        member add {{ node_name }} "$ETCD_LISTEN_PEER_URLS"`
+    if [ $? -ne 0 ]; then
+        echo "failed to add member {{ node_name }}"
+        exit 1
     fi
-    {% endif %}
+    # parse and export the environment returned by member add
+    export `echo $out | awk -F 'ETCD_' '{print "ETCD_"$2 "ETCD_"$3 "ETCD_"$4}' | sed s/\"//g`
+    {% endmacro -%}
+
+    {% macro init_cluster() -%}
+    export ETCD_INITIAL_CLUSTER_STATE=new
+    export ETCD_INITIAL_CLUSTER="
+    {%- for host in groups[etcd_peers_group] -%}
+    {%- if loop.last -%}
+    {{ hostvars[host]['ansible_hostname'] }}=http://{{ hostvars[host]['ansible_' + etcd_peer_interface]['ipv4']['address'] }}:{{ etcd_peer_port1 }},{{ hostvars[host]['ansible_hostname'] }}=http://{{ hostvars[host]['ansible_' + etcd_peer_interface]['ipv4']['address'] }}:{{ etcd_peer_port2 }}
+    {%- else -%}
+    {{ hostvars[host]['ansible_hostname'] }}=http://{{ hostvars[host]['ansible_' + etcd_peer_interface]['ipv4']['address'] }}:{{ etcd_peer_port1 }},{{ hostvars[host]['ansible_hostname'] }}=http://{{ hostvars[host]['ansible_' + etcd_peer_interface]['ipv4']['address'] }}:{{ etcd_peer_port2 }},
+    {%- endif -%}
+    {% endfor -%}
+    "
+    {% endmacro -%}
+
+    {% if run_as == "worker" -%}
+    # on worker nodes, run etcd in proxy mode
+    {{ add_proxy() }}
+    {% elif etcd_init_cluster -%}
+    # on master nodes, if the cluster is being initialized for first time then initialize it
+    {{ init_cluster() }}
+    {% else -%}
+    # if a new master node is being commissioned then add it to exisitng cluster
+    {{ add_member() }}
+    {% endif -%}
 
     #start etcd
     echo "==> starting etcd with environment:" `env`
@@ -45,16 +64,20 @@ start)
     ;;
 
 stop)
+    {% if run_as == "worker" -%}
+    echo "==> no 'stop' action for proxy"
+    {% else -%}
     #XXX: do better cleanup like remove the member from the cluster only if it was started
     out=`etcdctl member list | grep {{ node_name }} | awk -F ':' '{print $1}'`
     if [ "$out" != "" ]; then
         echo "==> removing member: " $out
         etcdctl member remove $out
     fi
+    {% endif -%}
     ;;
 
 post-stop)
-    #XXX: is there a case whe we should not cleanup the data dir on stop?
+    #XXX: is there a case when we should not cleanup the data dir on stop?
     rm -rf $ETCD_DATA_DIR
     ;;
 

--- a/ansible/roles/etcd/vars/main.yml
+++ b/ansible/roles/etcd/vars/main.yml
@@ -5,3 +5,8 @@ etcd_client_port1: 2379
 etcd_client_port2: 4001
 etcd_peer_port1: 2380
 etcd_peer_port2: 7001
+etcd_master_addr: "{{ node_addr }}"
+etcd_master_name: "{{ node_name }}"
+etcd_peers_group: "service-master"
+etcd_peer_interface: "{{ monitor_interface }}"
+etcd_init_cluster: true


### PR DESCRIPTION
This enhancement splits etcd cluster/peer configuration into two types/scenarios viz. cluster-init and member add.

cluster-init is the scenario when the etcd cluster needs to be initialized for the first time. This may involve a single node or multiple nodes at once.

member-add scenario is used for subsequent updates to the etcd cluster membership.

@erikh @shaleman 
This is a follow-up enhancement to #35. With this I am able to bring up a multi-master cluster with volmaster and netmaster serving their REST endpoint behind a VIP. PTAL when you a get chance.

Next I will try vendor these recent changes in the cluster repo and modify it's Vagrantfile that will allow bringing-up a multi-host demo cluster in the way I am trying it out locally.
