### PR TITLE
packer: parameterize builds to prevent atlas uploading when desired

### DIFF
--- a/packer/centos/Makefile
+++ b/packer/centos/Makefile
@@ -10,7 +10,10 @@ stop:
 	vagrant destroy -f
 
 build:
-	version=$$(cat VERSION) atlas_token=${ATLAS_TOKEN} packer build --force centos71.json
+	version=$$(cat VERSION) atlas_token="dummy" packer build --only build --force centos71.json
+
+release-build:
+	version=$$(cat VERSION) atlas_token=${ATLAS_TOKEN} packer build --only release --force centos71.json
 
 ssh: start
 	vagrant ssh

--- a/packer/centos/centos71.json
+++ b/packer/centos/centos71.json
@@ -1,6 +1,46 @@
 {
   "builders": [
     {
+      "name": "release",
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks7.cfg<enter>"
+      ],
+      "disk_size": 65536,
+      "guest_additions_path": "VBoxGuestAdditions.iso",
+      "guest_os_type": "RedHat_64",
+      "hard_drive_interface": "sata",
+      "headless": "{{ user `headless` }}",
+      "http_directory": "http",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_urls": [
+        "{{ user `iso_path` }}/{{ user `iso_name` }}",
+        "{{ user `iso_url` }}"
+      ],
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_password": "{{ user `ssh_password` }}",
+      "ssh_username": "{{ user `ssh_username` }}",
+      "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
+      "vboxmanage": [
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "2048"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "4"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "centos71"
+    },
+    {
+      "name": "build",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks7.cfg<enter>"
       ],
@@ -53,7 +93,8 @@
       "metadata": {
         "provider": "virtualbox",
         "version": "{{ user `version` }}"
-      }
+      },
+      "only": ["release"]
     }
   ]],
   "provisioners": [

--- a/packer/ubuntu/Makefile
+++ b/packer/ubuntu/Makefile
@@ -12,7 +12,10 @@ stop:
 restart: stop start
 
 build:
-	version=$$(cat VERSION) atlas_token=${ATLAS_TOKEN} packer build --force ubuntu1504.json
+	version=$$(cat VERSION) atlas_token="dummy" packer build --only build --force ubuntu1504.json
+
+release-build:
+	version=$$(cat VERSION) atlas_token=${ATLAS_TOKEN} packer build --only release --force ubuntu1504.json
 
 # XXX this is to work around a packer issue that causes the vbox startup to
 # fail every time it's run after the first time.

--- a/packer/ubuntu/ubuntu1504.json
+++ b/packer/ubuntu/ubuntu1504.json
@@ -1,6 +1,58 @@
 {
   "builders": [
     {
+      "name": "release",
+      "boot_command": [
+        "<esc><esc><enter><wait>",
+        "/install/vmlinuz noapic ",
+        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg ",
+        "debian-installer=en_US auto locale=en_US kbd-chooser/method=us ",
+        "hostname={{ user `hostname` }} ",
+        "fb=false debconf/frontend=noninteractive ",
+        "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA ",
+        "keyboard-configuration/variant=USA console-setup/ask_detect=false ",
+        "passwd/user-fullname={{ user `ssh_fullname` }} ",
+        "passwd/user-password={{ user `ssh_password` }} ",
+        "passwd/user-password-again={{ user `ssh_password` }} ",
+        "passwd/username={{ user `ssh_username` }} ",
+        "initrd=/install/initrd.gz -- <enter>"
+      ],
+      "disk_size": 65536,
+      "guest_additions_path": "VBoxGuestAdditions.iso",
+      "guest_os_type": "Ubuntu_64",
+      "hard_drive_interface": "sata",
+      "headless": "{{ user `headless` }}",
+      "http_directory": "http",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_urls": [
+        "{{ user `iso_path` }}/{{ user `iso_name` }}",
+        "{{ user `iso_url` }}"
+      ],
+      "shutdown_command": "echo '{{ user `ssh_password` }}'|sudo -S shutdown -P now",
+      "ssh_password": "{{ user `ssh_password` }}",
+      "ssh_username": "{{ user `ssh_username` }}",
+      "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
+      "vboxmanage": [
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "2048"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "4"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "ubuntu1504"
+    },
+    {
+      "name": "build",
       "boot_command": [
         "<esc><esc><enter><wait>",
         "/install/vmlinuz noapic ",
@@ -65,7 +117,8 @@
       "metadata": {
         "provider": "virtualbox",
         "version": "{{ user `version` }}"
-      }
+      },
+      "only": ["release"]
     }
   ]],
   "provisioners": [


### PR DESCRIPTION
@mapuri @DivyaVavili 

note that this duplicates the build definition at the top of each file. I could not find a nice way to do this without this block. I don't see the value in writing something more abstract to configure this block. Let me know if you have any ideas.

As for the rest, there are now two make targets: `make build` and `make release-build` for each build. The task differentiates on build name which is used to determine how post-processing works (which includes uploading to atlas or not)
