### PR TITLE
smaller images & faster builds

### DIFF
--- a/packer/centos/centos72.json
+++ b/packer/centos/centos72.json
@@ -187,8 +187,7 @@
         "script/vmware.sh",
         "script/virtualbox.sh",
         "script/parallels.sh",
-        "script/cmtool.sh",
-        "script/cleanup.sh"
+        "script/cmtool.sh"
       ],
       "type": "shell"
     },

--- a/packer/centos/script/cleanup.sh
+++ b/packer/centos/script/cleanup.sh
@@ -92,6 +92,10 @@ echo '==> Zeroing out empty area to save space in the final image'
 dd if=/dev/zero of=/EMPTY bs=1M || echo "dd exit code $? is suppressed"
 rm -f /EMPTY
 
+# Zero out boot as well
+dd if=/dev/zero of=/boot/EMPTY bs=1M || echo "dd exit code $? is suppressed"
+rm -f /boot/EMPTY
+
 # Block until the empty file has been removed, otherwise, Packer
 # will try to kill the box while the disk is still full and that's bad
 sync


### PR DESCRIPTION
This PR makes two changes:
It makes the cleanup script run only once at the end of the packer build. This lowers the amount of data written to disk on SSDs and speeds up the build. My current SSD is rated for 50 GB of writes per day and reducing the amounts of writes per build done by the "zeroing" via dd helps. The Ubuntu build is also running it only once.

The second change made to the cleanup.sh script will remove extra kernels from the system. This reduces the size of the uncompressed vmdk by approximately 200 MB. This should translate in ~50-70 MB reduction in size for the final box.
