### PR TITLE
centos: save images to load when provisioning

### DIFF
--- a/packer/centos/centos72.json
+++ b/packer/centos/centos72.json
@@ -205,6 +205,7 @@
       "type": "shell",
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
+        "script/docker-backup.sh",
         "script/cleanup.sh"
       ]
     }

--- a/packer/centos/script/docker-backup.sh
+++ b/packer/centos/script/docker-backup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+echo "==> Backing up the Docker images"
+mkdir /var/docker_images
+cd /var/docker_images
+images=$(sudo docker images | grep -v REPOSITORY | grep -v none | cut -d' ' -f1)
+for image in $images; do
+ echo $image
+ docker save $image > ${image/\//-}.tar
+done
+
+echo "==> Stopping docker"
+service docker stop
+echo "==> Removing the Docker folder"
+rm -rf /var/lib/docker/


### PR DESCRIPTION
This PR changes the build of the CentOS box build to make it save the images after they're pulled.

The goal is to restore these on whatever graph driver we set up after provisioning. This should be merged once we've taken care of loading these during provisioning.
