### PR TITLE
Makefile: squash when pulling submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ all:
 	cd packer && make
 
 vendor-ansible:
-	git subtree pull --prefix vendor/ansible https://github.com/contiv/ansible master
+	git subtree pull --squash --prefix vendor/ansible https://github.com/contiv/ansible master


### PR DESCRIPTION
Using `--squash` was recommended by @erikh to get rid of the merge conflicts. This has reduced merge conflicts down to a single conflict for me.

If this is the real command we should all be running, this needs to be in the Makefile.
