### PR TITLE
packer/centos: fix cleanup script to not remove perl and gcc

### DIFF
--- a/packer/centos/script/cleanup.sh
+++ b/packer/centos/script/cleanup.sh
@@ -71,7 +71,7 @@ yum -y install yum-utils
 package-cleanup --oldkernels --count=1
 
 echo "==> Remove packages needed for building guest tools"
-yum -y remove gcc cpp libmpc mpfr kernel-devel kernel-headers perl
+yum -y remove cpp libmpc mpfr kernel-devel kernel-headers
 
 echo "==> Clean up yum cache of metadata and packages to save space"
 yum -y --enablerepo='*' clean all


### PR DESCRIPTION
perl is a dependency for git, removing it removes git. gcc is installed by dev role so we should not remove it as well

/cc @erikh . This resolves the issue of missing git in packer builds.
