### PR TITLE
packer/centos, packer/ubuntu: add provisions to pass changelog metadata to atlas post processor

### DIFF
--- a/packer/centos/Makefile
+++ b/packer/centos/Makefile
@@ -14,7 +14,7 @@ build:
 	version=$$(cat VERSION) atlas_token="dummy" packer build --only build-vmware,build-virtualbox --force centos72.json
 
 release-build:
-	version=$$(cat VERSION) atlas_token=${ATLAS_TOKEN} packer build --only release-vmware,release-virtualbox --force centos72.json
+	changelog=${GITHUB_RELEASE_URL} version=$$(cat VERSION) atlas_token=${ATLAS_TOKEN} packer build --only release-vmware,release-virtualbox --force centos72.json
 
 ssh: start
 	vagrant ssh

--- a/packer/centos/centos72.json
+++ b/packer/centos/centos72.json
@@ -148,7 +148,8 @@
       "artifact_type": "vagrant.box",
       "metadata": {
         "provider": "virtualbox",
-        "version": "{{ user `version` }}"
+        "version": "{{ user `version` }}",
+        "changelog": "{{ user `changelog` }}"
       },
       "only": ["release-virtualbox"]
     },
@@ -159,7 +160,8 @@
       "artifact_type": "vagrant.box",
       "metadata": {
         "provider": "vmware_desktop",
-        "version": "{{ user `version` }}"
+        "version": "{{ user `version` }}",
+        "changelog": "{{ user `changelog` }}"
       },
       "only": ["release-vmware"]
     }
@@ -224,6 +226,7 @@
     "ssh_password": "vagrant",
     "ssh_username": "vagrant",
     "atlas_token": "{{ env `atlas_token` }}",
-    "version": "{{ env `version` }}"
+    "version": "{{ env `version` }}",
+    "changelog": "{{ env `changelog` }} "
   }
 }

--- a/packer/ubuntu/Makefile
+++ b/packer/ubuntu/Makefile
@@ -15,7 +15,7 @@ build:
 	version=$$(cat VERSION) atlas_token="dummy" packer build --only build --force ubuntu1504.json
 
 release-build:
-	version=$$(cat VERSION) atlas_token=${ATLAS_TOKEN} packer build --only release --force ubuntu1504.json
+	changelog=${GITHUB_RELEASE_URL} version=$$(cat VERSION) atlas_token=${ATLAS_TOKEN} packer build --only release --force ubuntu1504.json
 
 # XXX this is to work around a packer issue that causes the vbox startup to
 # fail every time it's run after the first time.

--- a/packer/ubuntu/ubuntu1504.json
+++ b/packer/ubuntu/ubuntu1504.json
@@ -116,7 +116,8 @@
       "artifact_type": "vagrant.box",
       "metadata": {
         "provider": "virtualbox",
-        "version": "{{ user `version` }}"
+        "version": "{{ user `version` }}",
+        "changelog": "{{ user `changelog` }}"
       },
       "only": ["release"]
     }
@@ -186,7 +187,8 @@
     "ssh_password": "vagrant",
     "ssh_username": "vagrant",
     "update": "false",
-    "version": "{{env `version`}}"
+    "version": "{{env `version`}}",
+    "changelog": "{{ env `changelog` }}"
   }
 }
 


### PR DESCRIPTION
/cc @erikh

This shall help us relate release atlas boxes back to github repo

Also I enabled basic build CI, so this PR shall test that as well. Let's wait on build to pass before merging.