### PR TITLE
packer/centos, packer/ubuntu: use description_markdown metadata field for changelog metadata in atlas post processor

### DIFF
--- a/packer/centos/centos72.json
+++ b/packer/centos/centos72.json
@@ -149,7 +149,7 @@
       "metadata": {
         "provider": "virtualbox",
         "version": "{{ user `version` }}",
-        "changelog": "{{ user `changelog` }}"
+        "description_markdown": "[changelog]({{ user `changelog` }})"
       },
       "only": ["release-virtualbox"]
     },
@@ -161,7 +161,7 @@
       "metadata": {
         "provider": "vmware_desktop",
         "version": "{{ user `version` }}",
-        "changelog": "{{ user `changelog` }}"
+        "description_markdown": "[changelog]({{ user `changelog` }})"
       },
       "only": ["release-vmware"]
     }

--- a/packer/ubuntu/ubuntu1504.json
+++ b/packer/ubuntu/ubuntu1504.json
@@ -117,7 +117,7 @@
       "metadata": {
         "provider": "virtualbox",
         "version": "{{ user `version` }}",
-        "changelog": "{{ user `changelog` }}"
+        "description_markdown": "[changelog]({{ user `changelog` }})"
       },
       "only": ["release"]
     }


### PR DESCRIPTION
from atlas API looks like it expects description to set in `description_markdown` field