### PR TITLE
packer/centos: clean up the cleanup script

### DIFF
--- a/packer/centos/Makefile
+++ b/packer/centos/Makefile
@@ -10,7 +10,7 @@ stop:
 	vagrant destroy -f
 
 build:
-	version=$$(cat VERSION) atlas_token="dummy" packer build --only build-virtualbox --force centos73.json
+	version=$$(cat VERSION) atlas_token="dummy" packer build -color=false --only build-virtualbox --force centos73.json
 
 release-build:
 	changelog=${GITHUB_RELEASE_URL} version=$$(cat VERSION) atlas_token=${ATLAS_TOKEN} packer build --only release-virtualbox --force centos73.json

--- a/packer/centos/script/cleanup.sh
+++ b/packer/centos/script/cleanup.sh
@@ -94,6 +94,9 @@ for i in $UNNEEDED_LOCALES; do rm -rf $i; done
 ls -ahl /usr/share/locale
 echo "==> Finished removing unneeded locales"
 
+echo "==> Removing unneeded background images"
+rm -f /usr/share/backgrounds/*.png
+rm -f /usr/share/backgrounds/*.jpg
 
 echo '==> Zeroing out empty area to save space in the final image'
 # Zero out the free space to save space in the final image.  Contiguous

--- a/packer/centos/script/cleanup.sh
+++ b/packer/centos/script/cleanup.sh
@@ -83,6 +83,18 @@ echo "==> Rebuild RPM DB"
 rpmdb --rebuilddb
 rm -f /var/lib/rpm/__db*
 
+echo "==> Remove unneeded locales"
+localedef --list-archive | grep -a -v ^en | xargs localedef --delete-from-archive
+cp /usr/lib/locale/locale-archive /usr/lib/locale/locale-archive.tmpl
+build-locale-archive
+ls -ahl /usr/lib/locale/locale-archive
+cd /usr/share/locale/
+UNNEEDED_LOCALES=$(ls /usr/share/locale/ | grep -v ^en)
+for i in $UNNEEDED_LOCALES; do rm -rf $i; done
+ls -ahl /usr/share/locale
+echo "==> Finished removing unneeded locales"
+
+
 echo '==> Zeroing out empty area to save space in the final image'
 # Zero out the free space to save space in the final image.  Contiguous
 # zeroed space compresses down to nothing.

--- a/packer/ubuntu/Makefile
+++ b/packer/ubuntu/Makefile
@@ -12,7 +12,7 @@ stop:
 restart: stop start
 
 build:
-	version=$$(cat VERSION) atlas_token="dummy" packer build --only build --force ubuntu1604.json
+	version=$$(cat VERSION) atlas_token="dummy" packer build -color=false --only build --force ubuntu1604.json
 
 release-build:
 	changelog=${GITHUB_RELEASE_URL} version=$$(cat VERSION) atlas_token=${ATLAS_TOKEN} packer build --only release --force ubuntu1604.json


### PR DESCRIPTION
~This PR makes the cleanup.sh CentOS zero out the swap block device. This should save a bit more space in the final image.~

This PR makes the following changes:
- writes zeroes to the swap block device to avoid using up space
- removes unneeded locales to free up some more space
- removes some unneeded backgrounds
- disables color output to get rid of most escape codes from the build output