### PR TITLE
Prepare for new CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,17 @@
+#!groovy
+pipeline {
+  agent { label 'public' }
+  options {
+    timeout(time: 30, unit: 'MINUTES')
+  }
+  stages {
+    stage('Build CentOS') {
+      steps {
+        sh '''
+          set -euo pipefail
+          make -C packer build-centos
+        '''
+      }
+    }
+  }
+}

--- a/Jenkinsfile-onmerge
+++ b/Jenkinsfile-onmerge
@@ -1,0 +1,1 @@
+Jenkinsfile

--- a/Jenkinsfile-ontag
+++ b/Jenkinsfile-ontag
@@ -1,0 +1,24 @@
+#!groovy
+pipeline {
+  agent { label 'public' }
+  options {
+    timeout(time: 30, unit: 'MINUTES')
+  }
+  stages {
+    stage('Build Release') {
+      steps {
+        sh '''
+          set -euo pipefail
+
+          # TODO(NB): Should github-release be installed on the slave beforehand like other dependencies?
+          export GOPATH="${WORKSPACE}"
+          export PATH="${PATH}:${GOPATH}/bin"
+          go get github.com/aktau/github-release
+
+          make -C packer/centos release-build
+          make -C packer/centos release-github
+        '''
+      }
+    }
+  }
+}

--- a/packer/centos/Makefile
+++ b/packer/centos/Makefile
@@ -1,3 +1,7 @@
+VERSION ?= $(shell git describe --tags --always)
+PREVIOUS_VERSION ?= $(shell git describe --abbrev=0 --tags $(VERSION)^)
+GITHUB_RELEASE_URL ?= https://github.com/contiv/build/releases/tag/$(VERSION)
+
 all: stop build add start 
 
 add:
@@ -9,11 +13,20 @@ start:
 stop:
 	vagrant destroy -f
 
-build:
-	version=$$(cat VERSION) atlas_token="dummy" packer build -color=false --only build-virtualbox --force centos73.json
-
-release-build:
-	changelog=${GITHUB_RELEASE_URL} version=$$(cat VERSION) atlas_token=${ATLAS_TOKEN} packer build --only release-virtualbox --force centos73.json
-
 ssh: start
 	vagrant ssh
+
+# .SHELLSTATUS doesn't seem to work as advertised, so we don't have a proper way to check if the git command failed
+# (for example because git is not installed).  Therefore the next best thing is just to see if it was set to anything.
+check-version:
+	test -n "$(VERSION)"
+	test -n "$(PREVIOUS_TAG)"
+
+build: check-version
+	version="$(VERSION)" atlas_token="dummy" packer build -color=false --only build-virtualbox --force centos73.json
+
+release-build: check-version
+	changelog="$(GITHUB_RELEASE_URL)" version="$(VERSION)" atlas_token="$(ATLAS_TOKEN)" packer build --only release-virtualbox --force centos73.json
+
+release-github: check-version
+	github-release -v release -p -r build -t "$(VERSION)" -d "**Changelog**<br/> $$(git log --oneline --no-merges --reverse $(PREVIOUS_VERSION)..$(VERSION))"

--- a/packer/ubuntu/Makefile
+++ b/packer/ubuntu/Makefile
@@ -1,3 +1,7 @@
+VERSION ?= $(shell git describe --tags --always)
+PREVIOUS_VERSION ?= $(shell git describe --abbrev=0 --tags $(VERSION)^)
+GITHUB_RELEASE_URL ?= https://github.com/contiv/build/releases/tag/$(VERSION)
+
 all: stop build add start 
 
 add:
@@ -9,18 +13,20 @@ start:
 stop:
 	vagrant destroy -f
 
-restart: stop start
-
-build:
-	version=$$(cat VERSION) atlas_token="dummy" packer build -color=false --only build --force ubuntu1604.json
-
-release-build:
-	changelog=${GITHUB_RELEASE_URL} version=$$(cat VERSION) atlas_token=${ATLAS_TOKEN} packer build --only release --force ubuntu1604.json
-
-# XXX this is to work around a packer issue that causes the vbox startup to
-# fail every time it's run after the first time.
-rmcache:
-	rm -rf packer_cache
-
 ssh: start
 	vagrant ssh
+
+# .SHELLSTATUS doesn't seem to work as advertised, so we don't have a proper way to check if the git command failed
+# (for example because git is not installed).  Therefore the next best thing is just to see if it was set to anything.
+check-version:
+	test -n "$(VERSION)"
+	test -n "$(PREVIOUS_TAG)"
+
+build: check-version
+	version="$(VERSION)" atlas_token="dummy" packer build -color=false --only build --force ubuntu1604.json
+
+release-build: check-version
+	changelog="$(GITHUB_RELEASE_URL)" version="$(VERSION)" atlas_token="$(ATLAS_TOKEN)" packer build --only release --force ubuntu1604.json
+
+release-github: check-version
+	github-release -v release -p -r build -t "$(VERSION)" -d "**Changelog**<br/> $$(git log --oneline --no-merges --reverse $(PREVIOUS_VERSION)..$(VERSION))"


### PR DESCRIPTION
In addition to adding hooks for the new CI, the version detection
was changed to use git tags directly, instead of having an external
process figure out the git tag, add it to the VERSION file, and
commit/push the change.  Using this method, the version should be
more accurate, and we'll be less likely to clobber a previous
release's artifacts accidentally.  Additionally, this removes the
requirement that the CI be able to commit+push to the git repository.